### PR TITLE
I believe there is a bug in hieroglyphyNumber or in __main__ depending on your point of view

### DIFF
--- a/hieroglyphy.py
+++ b/hieroglyphy.py
@@ -216,6 +216,7 @@ class Hieroglyphy:
         """
         Returns a hieroglyphied number as a number.
         """
+		n = int(n)
         if (n <= 9): 
             return self.numbers[n]
 


### PR DESCRIPTION
$ python hieroglyphy.py number 5
<snip>
[*] Encoded number below: 5
+((!+[]+!![]+!![]+!![]+!![]+[]))

But it should return !+[]+!![]+!![]+!![]+!![] according to
http://patriciopalladino.com/files/hieroglyphy/ (and my ruby version
does the same)

the number 5 was being treated as "5".  This can be fixed either by
changing **main** to print hy.hieroglyphyNumber(int(sys.argv[2]))
or by changing hieroglyphyNumber to include:
n = int(n)
which is what this commit does.  This prevents other calling code from
having the same problem, however it means that calling code must ensure
it calls hieroglyphyString when "glyph"ing "5", not hieroglyphyNumber
