### PR TITLE
Bugfix [object Object] string

### DIFF
--- a/hieroglyphy.py
+++ b/hieroglyphy.py
@@ -56,7 +56,7 @@ class Hieroglyphy:
                     "9" : "(" + self.numbers[9] + "+[])"
         }
 
-        self._object_Object = "{}+[]"
+        self._object_Object = "[]+{}"
         self._NaN = "+{}+[]"
         self._true = "!![]+[]"
         self._false = "![]+[]"


### PR DESCRIPTION
Taking into account you are converting to string with [], you must start with a string to append the constructor name
({}).toString() => []+{}
